### PR TITLE
fixes in testfiles: missing attributes

### DIFF
--- a/develop/tests/iati/testfiles/4.1.1.xml
+++ b/develop/tests/iati/testfiles/4.1.1.xml
@@ -14,7 +14,7 @@
   <!--reporting-org starts-->
   <reporting-org ref="AA-AAA-123456789" type="40" secondary-reporter="0">
    <narrative>Organisation name</narrative>
-   <narrative xml:lang="">Nom de l'organisme</narrative>
+   <narrative>Nom de l'organisme</narrative>
   </reporting-org>
   <!--reporting-org ends-->
 

--- a/develop/tests/iati/testfiles/4.1.1.xml
+++ b/develop/tests/iati/testfiles/4.1.1.xml
@@ -5,7 +5,7 @@
 <iati-activities generated-datetime="2014-09-10T07:15:37Z" version="2.03" linked-data-default="http://data.example.org/">
 
  <!--iati-activity starts-->
- <iati-activity xml:lang= default-currency="USD" last-updated-datetime="2014-09-10T07:15:37Z" humanitarian="1" linked-data-uri="http://data.example.org/123456789" hierarchy="1" budget-not-provided="1">
+ <iati-activity default-currency="USD" last-updated-datetime="2014-09-10T07:15:37Z" humanitarian="1" linked-data-uri="http://data.example.org/123456789" hierarchy="1" budget-not-provided="1">
 
   <!--iati-identifier starts-->
   <iati-identifier>AA-AAA-123456789-ABC123</iati-identifier>
@@ -14,7 +14,7 @@
   <!--reporting-org starts-->
   <reporting-org ref="AA-AAA-123456789" type="40" secondary-reporter="0">
    <narrative>Organisation name</narrative>
-   <narrative xml:lang=>Nom de l'organisme</narrative>
+   <narrative xml:lang="">Nom de l'organisme</narrative>
   </reporting-org>
   <!--reporting-org ends-->
 

--- a/develop/tests/iati/testfiles/4.5.1.xml
+++ b/develop/tests/iati/testfiles/4.5.1.xml
@@ -5,7 +5,7 @@
 <iati-organisations generated-datetime="2014-09-10T07:15:37Z" version="2.03">
 
  <!--iati-organisation starts-->
- <iati-organisation default-currency="EUR" last-updated-datetime="2014-09-10T07:15:37Z" xml:lang=>
+ <iati-organisation default-currency="EUR" last-updated-datetime="2014-09-10T07:15:37Z">
 
   <!--organisation-identifier starts-->
   <organisation-identifier>AA-AAA-123456789</organisation-identifier>
@@ -21,7 +21,7 @@
   <!--reporting-org starts-->
   <reporting-org ref="AA-AAA-123456789" type="40" secondary-reporter="0">
    <narrative>Organisation name</narrative>
-   <narrative xml:lang=>Nom de l'organisme</narrative>
+   <narrative xml:lang="">Nom de l'organisme</narrative>
   </reporting-org>
   <!--reporting-org ends-->
 
@@ -60,7 +60,7 @@
    <value currency="USD" value-date="2014-01-01">25000000</value>
    <budget-line ref="1234">
     <value currency="USD" value-date="2014-01-01">2000000</value>
-    <narrative xml:lang=>Budget Line</narrative>
+    <narrative xml:lang="">Budget Line</narrative>
    </budget-line>
   </recipient-region-budget>
   <!--recipient-region-budget ends-->

--- a/develop/tests/iati/testfiles/4.5.1.xml
+++ b/develop/tests/iati/testfiles/4.5.1.xml
@@ -21,7 +21,7 @@
   <!--reporting-org starts-->
   <reporting-org ref="AA-AAA-123456789" type="40" secondary-reporter="0">
    <narrative>Organisation name</narrative>
-   <narrative xml:lang="">Nom de l'organisme</narrative>
+   <narrative>Nom de l'organisme</narrative>
   </reporting-org>
   <!--reporting-org ends-->
 
@@ -60,7 +60,7 @@
    <value currency="USD" value-date="2014-01-01">25000000</value>
    <budget-line ref="1234">
     <value currency="USD" value-date="2014-01-01">2000000</value>
-    <narrative xml:lang="">Budget Line</narrative>
+    <narrative>Budget Line</narrative>
    </budget-line>
   </recipient-region-budget>
   <!--recipient-region-budget ends-->

--- a/develop/tests/iati/testfiles/6.1.4.xml
+++ b/develop/tests/iati/testfiles/6.1.4.xml
@@ -291,7 +291,7 @@
   <document-link format="application/vnd.oasis.opendocument.text" url="http:www.example.org/docs/report_en.odt">
    <title>
     <narrative>Project Report 2013</narrative>
-    <narrative xml:lang=>Rapport de projet 2013</narrative>
+    <narrative xml:lang="">Rapport de projet 2013</narrative>
    </title>
    <description>
      <narrative> Description of the content of the project report or guidance on where to access the relevant information in this report </narrative>

--- a/develop/tests/iati/testfiles/6.1.4.xml
+++ b/develop/tests/iati/testfiles/6.1.4.xml
@@ -291,7 +291,7 @@
   <document-link format="application/vnd.oasis.opendocument.text" url="http:www.example.org/docs/report_en.odt">
    <title>
     <narrative>Project Report 2013</narrative>
-    <narrative xml:lang="">Rapport de projet 2013</narrative>
+    <narrative>Rapport de projet 2013</narrative>
    </title>
    <description>
      <narrative> Description of the content of the project report or guidance on where to access the relevant information in this report </narrative>

--- a/develop/tests/iati/testfiles/6.1.5.xml
+++ b/develop/tests/iati/testfiles/6.1.5.xml
@@ -288,7 +288,7 @@
   <!--transaction ends-->
 
   <!--document-link starts-->
-  <document-link format= url="http:www.example.org/docs/report_en.odt">
+  <document-link url="http:www.example.org/docs/report_en.odt">
    <title>
     <narrative>Project Report 2013</narrative>
     <narrative xml:lang="fr">Rapport de projet 2013</narrative>
@@ -329,7 +329,7 @@
     <narrative>Result description text</narrative>
    </description>
    <!--result-document-link example starts-->
-   <document-link format= url="http:www.example.org/docs/result_en.odt">
+   <document-link url="http:www.example.org/docs/result_en.odt">
     <title>
      <narrative>Results Report 2013</narrative>
     </title>

--- a/develop/tests/iati/testfiles/6.14.1.xml
+++ b/develop/tests/iati/testfiles/6.14.1.xml
@@ -202,7 +202,7 @@
 
   <!--policy-marker starts-->
   <policy-marker vocabulary="1" code="2"/>
-  <policy-marker vocabulary="1" code="9" significance=/>
+  <policy-marker vocabulary="1" code="9"/>
   <policy-marker vocabulary="99" vocabulary-uri="http://example.com/vocab.html" code="A1" significance="3">
    <narrative>Code A1</narrative>
   </policy-marker>

--- a/develop/tests/iati/testfiles/6.8.1.xml
+++ b/develop/tests/iati/testfiles/6.8.1.xml
@@ -1,3 +1,5 @@
+<iati-activities generated-datetime="2014-09-10T07:15:37Z" version="2.03" linked-data-default="http://data.example.org/">
+ <iati-activity>
   <reporting-org ref="AA-AAA-123456789" type="40" secondary-reporter="0">
    <narrative>Organisation name</narrative>
    <narrative xml:lang="fr">Nom de l'organisme</narrative>
@@ -42,7 +44,7 @@
 
   <!--other-identifier starts-->
   <other-identifier ref="ABC123-XYZ" type="A1">
-   <owner-org ref=>
+   <owner-org>
    </owner-org>
   </other-identifier>
   <!--other-identifier ends-->

--- a/develop/tests/iati/testfiles/6.9.1.xml
+++ b/develop/tests/iati/testfiles/6.9.1.xml
@@ -242,7 +242,7 @@
    <period-start iso-date="2014-01-01" />
    <period-end iso-date="2014-12-31" />
    <value currency="EUR" value-date="2014-01-01">3000</value>
-   <provider-org provider-activity-id="BB-BBB-123456789-1234AA" type="10" ref="">
+   <provider-org provider-activity-id="BB-BBB-123456789-1234AA" type="10">
    </provider-org>
    <receiver-org receiver-activity-id="AA-AAA-123456789-1234" type="23">
    </receiver-org>

--- a/develop/tests/iati/testfiles/6.9.1.xml
+++ b/develop/tests/iati/testfiles/6.9.1.xml
@@ -242,7 +242,7 @@
    <period-start iso-date="2014-01-01" />
    <period-end iso-date="2014-12-31" />
    <value currency="EUR" value-date="2014-01-01">3000</value>
-   <provider-org provider-activity-id="BB-BBB-123456789-1234AA" type="10" ref=">
+   <provider-org provider-activity-id="BB-BBB-123456789-1234AA" type="10" ref="">
    </provider-org>
    <receiver-org receiver-activity-id="AA-AAA-123456789-1234" type="23">
    </receiver-org>
@@ -271,7 +271,7 @@
    </description>
    <provider-org provider-activity-id="BB-BBB-123456789-1234AA" type="10">
    </provider-org>
-   <receiver-org receiver-activity-id="AA-AAA-123456789-1234" type="23" ref=>
+   <receiver-org receiver-activity-id="AA-AAA-123456789-1234" type="23">
    </receiver-org>
    <disbursement-channel code="1" />
    <!--Note: only a recipient-region OR a recipient-country is expected-->

--- a/develop/tests/iati/testfiles/8.10.1.xml
+++ b/develop/tests/iati/testfiles/8.10.1.xml
@@ -412,7 +412,7 @@
         <document-date iso-date="2014-02-05" />
        </document-link>
       </target>
-      <actual value=>
+      <actual>
        <location ref="AF-KAN" />
        <location ref="KH-PNH" />
        <dimension name="sex" value="female" />

--- a/develop/tests/iati/testfiles/8.8.1.xml
+++ b/develop/tests/iati/testfiles/8.8.1.xml
@@ -367,7 +367,7 @@
      <reference vocabulary="7" code="861" />
      <reference vocabulary="99" code="B1" indicator-uri="http://example.com/indicators.html" />
 <!--result-baseline starts-->
-     <baseline year="2012" iso-date="2012-01-01" value=>
+     <baseline year="2012" iso-date="2012-01-01">
       <location ref="AF-KAN" />
       <location ref="KH-PNH" />
       <dimension name="sex" value="female" />

--- a/develop/tests/iati/testfiles/8.9.1.xml
+++ b/develop/tests/iati/testfiles/8.9.1.xml
@@ -392,7 +392,7 @@
      <period>
       <period-start iso-date="2013-01-01" />
       <period-end iso-date="2013-03-31" />
-      <target value=>
+      <target>
        <location ref="AF-KAN" />
        <location ref="KH-PNH" />
        <dimension name="sex" value="female" />


### PR DESCRIPTION
Specifying `... attrib= ...` is not valid XML. Two options:

1. Not specifying the attribute at all: can (also) result in schema validation errors (separate feedback)
2. Specifying an empty value `... attrib="" ...`: it will pass schema validation if the attribute is required; it may also trigger a codelist error (invalid code) if it is supposed to contain a code.

This commit mixes both approaches.